### PR TITLE
Fix for Issue 1

### DIFF
--- a/src/MainCLI.java
+++ b/src/MainCLI.java
@@ -342,7 +342,7 @@ public class MainCLI {
 		URL obj=new URL(url);
 		HttpURLConnection httpcon=(HttpURLConnection) obj.openConnection();
 		httpcon.setRequestMethod("GET");
-		httpcon.setRequestProperty("User_Agent", "Mozilla/5.0");
+		httpcon.setRequestProperty("User-Agent", "Mozilla/5.0");
 		int responseCode=httpcon.getResponseCode();
 		if(responseCode==HttpURLConnection.HTTP_OK) {
 			BufferedReader brt=new BufferedReader(new InputStreamReader(httpcon.getInputStream()));


### PR DESCRIPTION
Fixes the syntax for the User Agent call which causes the HttpURLConnection class usage to be compatible with JSE 8.
This should fix the issue that caused the Twitch Tracker retrieving option to be broken in JSE 8.