### PR TITLE
Release 2.0aH

### DIFF
--- a/src/TwitchRecover.CLI/CLI.java
+++ b/src/TwitchRecover.CLI/CLI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/CLI.java
+++ b/src/TwitchRecover.CLI/CLI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/CLIHandler.java
+++ b/src/TwitchRecover.CLI/CLIHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/CLIHandler.java
+++ b/src/TwitchRecover.CLI/CLIHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Enums/oType.java
+++ b/src/TwitchRecover.CLI/Enums/oType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Enums/oType.java
+++ b/src/TwitchRecover.CLI/Enums/oType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Enums/vType.java
+++ b/src/TwitchRecover.CLI/Enums/vType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Enums/vType.java
+++ b/src/TwitchRecover.CLI/Enums/vType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/ClipHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/ClipHandler.java
@@ -183,8 +183,7 @@ public class ClipHandler {
         for(String result: results){
             System.out.print("\n"+result);
         }
-        System.out.print("\n\nDo you wish to export the results ('y' for yes, 'n' for no)?: "); //TODO: Add boolean checker for beta and final release.
-        if(CLIHandler.sc.next().equals("y")){
+        if(CoreHandler.booleanPrompt("Do you wish to export the results")){
             System.out.print("\nPlease input the file path where to export the results: ");
             clip.setFP(CLIHandler.sc.next());
             clip.exportResults();

--- a/src/TwitchRecover.CLI/Handlers/ClipHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/ClipHandler.java
@@ -162,7 +162,7 @@ public class ClipHandler {
         else{
             System.out.print("\nPlease input the stream link from an analytics website (Twitch Tracker or Streamscharts): ");
             String[] data= WebsiteRetrieval.getData(CLIHandler.sc.next());
-            clip.setValues(Long.parseLong(data[1]), Long.parseLong(data[3]));
+            clip.setValues(Long.parseLong(data[1]), Long.parseLong(data[3].substring(0, data[3].indexOf("."))));
         }
         System.out.print(
                   "\nPlease enter y if you have Wfuzz installed and n if not: "

--- a/src/TwitchRecover.CLI/Handlers/ClipHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/ClipHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/ClipHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/ClipHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/CoreHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/CoreHandler.java
@@ -115,4 +115,26 @@ public class CoreHandler {
         }
         return highlightURL;
     }
+
+    /**
+     * This method prompts the user
+     * for a boolean input and handles
+     * incorrect user input.
+     * @param prompt    String value representing the question to prompt the user.
+     * @return boolean  Boolean value representing the user's desired option, returns true for yes and false for no.
+     */
+    protected static boolean booleanPrompt(String prompt){
+        System.out.print("\n\n"+prompt+" ('y' for yes, 'n' for no)?: ");
+        String line=CLIHandler.sc.next();
+        while(!(line.toLowerCase().startsWith("y")||line.toLowerCase().startsWith("n"))){
+            System.out.print(
+                      "\nERROR: Invalid input."
+                    + "\nPlease enter 'y' for yes or 'n' for no based on your desired selection."
+            );
+        }
+        if(line.startsWith("y")){
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/TwitchRecover.CLI/Handlers/CoreHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/CoreHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/CoreHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/CoreHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/HighlightHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/HighlightHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/HighlightHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/HighlightHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/MassHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/MassHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/MassHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/MassHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/StreamHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/StreamHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/StreamHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/StreamHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/VODHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/VODHandler.java
@@ -109,8 +109,17 @@ public class VODHandler {
         }
         vod.retrieveVOD(wf);
         Feeds feeds=vod.retrieveVODFeeds();
-        int quality=CoreHandler.selectFeeds(feeds, oType.Recover);
-        System.out.print("\nResult: "+feeds.getFeed(quality-1));
+        if(feeds==null){
+            System.out.print(
+                      "\nNO RESULTS FOUND."
+                    + "\nThe VOD cannot be found on Twitch servers."
+            );
+        }
+        else{
+            int quality=CoreHandler.selectFeeds(feeds, oType.Recover);
+            System.out.print("\nResult: "+feeds.getFeed(quality-1));
+        }
+
     }
 
     /**

--- a/src/TwitchRecover.CLI/Handlers/VODHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/VODHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/VODHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/VODHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/VideoHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/VideoHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Handlers/VideoHandler.java
+++ b/src/TwitchRecover.CLI/Handlers/VideoHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Prompts.java
+++ b/src/TwitchRecover.CLI/Prompts.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.CLI/Prompts.java
+++ b/src/TwitchRecover.CLI/Prompts.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/API/API.java
+++ b/src/TwitchRecover.Core/API/API.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */
@@ -25,11 +25,12 @@ import TwitchRecover.Core.FileIO;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -163,23 +164,65 @@ public class API {
      * This method parses and returns
      * the token and signature values
      * from a given API JSON response.
-     * @param response      String arraylist containing the JSON response from the API call.
+     * @param response      String containing the JSON response from the API call.
+     * @param isVOD         Boolean value that is true if the token is for a video and false if it is for a stream.
      * @return String[]     String array containing the token and signature values.
      * String[2]: 0: Token; 1: Signature.
      */
-    protected static String[] parseToken(ArrayList<String> response){
+    protected static String[] parseToken(String response, boolean isVOD){
         String[] results=new String[2];
         //Parse JSON:
-        JSONParser parse=new JSONParser();
-        JSONObject jObj=null;
-        try{
-            jObj=(JSONObject) parse.parse(response.get(0));
+        JSONObject jO=new JSONObject(response);
+        JSONObject tokenCat=jO.getJSONObject("data");
+        if(isVOD){
+            tokenCat=tokenCat.getJSONObject("videoPlaybackAccessToken");
         }
-        catch(ParseException ignored){}
-        String token=jObj.get("token").toString();
-        results[1]=jObj.get("sig").toString();
+        else{
+            tokenCat=tokenCat.getJSONObject("streamPlaybackAccessToken");
+        }
+        String token=tokenCat.getString("value");
+        results[1]=tokenCat.getString("signature");
         //Remove back slashes from token:
         results[0]=token.replace("\\", "");
         return results;
+    }
+
+    /**
+     * This method retrieves an
+     * @param id            String value representing the ID to input into the query.
+     * @param isVOD         Boolean value that is true if the token being retrieved is for a VOD and false if it is for a live stream.
+     * @return String[]     String array containing the token and signature values.
+     * String[2]: 0: Token; 1: Signature.
+     */
+    protected static String[] getToken(String id, boolean isVOD){
+        String json;
+        String response="";
+        if(isVOD){
+            json="{\"operationName\": \"PlaybackAccessToken\",\"variables\": {\"isLive\": false,\"login\": \"\",\"isVod\": true,\"vodID\": \"" + id + "\",\"playerType\": \"channel_home_live\"},\"extensions\": {\"persistedQuery\": {\"version\": 1,\"sha256Hash\": \"0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712\"}}}";
+        }
+        else{
+            json="{\"operationName\": \"PlaybackAccessToken\",\"variables\": {\"isLive\": true,\"login\": \""+id+"\",\"isVod\": false,\"vodID\": \"\",\"playerType\": \"channel_home_live\"},\"extensions\": {\"persistedQuery\": {\"version\": 1,\"sha256Hash\": \"0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712\"}}}";
+        }
+        try{
+            CloseableHttpClient httpClient=HttpClients.createDefault();
+            HttpPost httppost=new HttpPost("https://gql.twitch.tv/gql");
+            httppost.addHeader("Content-Type", "text/plain;charset=UTF-8");
+            httppost.addHeader("Client-ID", "kimne78kx3ncx6brgo4mv6wki5h1ko");
+            StringEntity sE=new StringEntity(json);
+            httppost.setEntity(sE);
+            CloseableHttpResponse httpResponse=httpClient.execute(httppost);
+            if(httpResponse.getStatusLine().getStatusCode()==200){
+                BufferedReader br=new BufferedReader(new InputStreamReader(httpResponse.getEntity().getContent()));
+                String line;
+                while ((line = br.readLine()) != null) {
+                    response+=line;
+                }
+                br.close();
+            }
+            httpResponse.close();
+            httpClient.close();
+        }
+        catch(Exception ignored){}
+        return parseToken(response, isVOD);
     }
 }

--- a/src/TwitchRecover.Core/API/API.java
+++ b/src/TwitchRecover.Core/API/API.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/API/ClipsAPI.java
+++ b/src/TwitchRecover.Core/API/ClipsAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/API/ClipsAPI.java
+++ b/src/TwitchRecover.Core/API/ClipsAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/API/LiveAPI.java
+++ b/src/TwitchRecover.Core/API/LiveAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */
@@ -18,8 +18,6 @@
 package TwitchRecover.Core.API;
 
 import TwitchRecover.Core.Feeds;
-
-import java.util.ArrayList;
 
 /**
  * This class handles all
@@ -48,7 +46,6 @@ public class LiveAPI {
      * String[2]: 0: Token; 1: Signature.
      */
     private static String[] getLiveToken(String channel){
-        ArrayList<String> responseContents=API.getReq("https://api.twitch.tv/api/channels/"+channel+"/access_token");
-        return API.parseToken(responseContents);
+        return API.getToken(channel, false);
     }
 }

--- a/src/TwitchRecover.Core/API/LiveAPI.java
+++ b/src/TwitchRecover.Core/API/LiveAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/API/VideoAPI.java
+++ b/src/TwitchRecover.Core/API/VideoAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */
@@ -31,7 +31,6 @@ import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 
 /**
  * This class handles all
@@ -112,7 +111,6 @@ public class VideoAPI {
      * String[2]: 0: Token; 1: Signature.
      */
     private static String[] getVODToken(long VODID){
-        ArrayList<String> responseContents=API.getReq("https://api.twitch.tv/api/vods/"+VODID+"/access_token");
-        return API.parseToken(responseContents);
+        return API.getToken(String.valueOf(VODID), true);
     }
 }

--- a/src/TwitchRecover.Core/API/VideoAPI.java
+++ b/src/TwitchRecover.Core/API/VideoAPI.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Clips.java
+++ b/src/TwitchRecover.Core/Clips.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Clips.java
+++ b/src/TwitchRecover.Core/Clips.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Compute.java
+++ b/src/TwitchRecover.Core/Compute.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Compute.java
+++ b/src/TwitchRecover.Core/Compute.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Converter.java
+++ b/src/TwitchRecover.Core/Converter.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Converter.java
+++ b/src/TwitchRecover.Core/Converter.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/Download.java
+++ b/src/TwitchRecover.Core/Downloader/Download.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/Download.java
+++ b/src/TwitchRecover.Core/Downloader/Download.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/FileHandler.java
+++ b/src/TwitchRecover.Core/Downloader/FileHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/FileHandler.java
+++ b/src/TwitchRecover.Core/Downloader/FileHandler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/M3U8Handler.java
+++ b/src/TwitchRecover.Core/Downloader/M3U8Handler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Downloader/M3U8Handler.java
+++ b/src/TwitchRecover.Core/Downloader/M3U8Handler.java
@@ -39,7 +39,7 @@ class M3U8Handler {
     protected static ArrayList<String> getChunks(String url) throws IOException {
         ArrayList<String> chunks=new ArrayList<String>();
         String baseURL="";
-        String pattern = "([a-z0-9\\-]*.[a-z_]*.[net||com||tv]*\\/[a-z0-9_]*\\/[a-zA-Z0-9]*\\/)index-dvr.m3u8";
+        String pattern = "([a-z0-9\\-]*.[a-z_]*.[net||com||tv]*\\/[a-z0-9_]*\\/[a-zA-Z0-9]*\\/)index[0-9a-zA-Z-]*.m3u8";
         Pattern r = Pattern.compile(pattern);
         Matcher m = r.matcher(url);
         if(m.find()) {

--- a/src/TwitchRecover.Core/Downloader/M3U8Handler.java
+++ b/src/TwitchRecover.Core/Downloader/M3U8Handler.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/ContentType.java
+++ b/src/TwitchRecover.Core/Enums/ContentType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/ContentType.java
+++ b/src/TwitchRecover.Core/Enums/ContentType.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/FileExtension.java
+++ b/src/TwitchRecover.Core/Enums/FileExtension.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/FileExtension.java
+++ b/src/TwitchRecover.Core/Enums/FileExtension.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/Quality.java
+++ b/src/TwitchRecover.Core/Enums/Quality.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/Quality.java
+++ b/src/TwitchRecover.Core/Enums/Quality.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/Timeout.java
+++ b/src/TwitchRecover.Core/Enums/Timeout.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Enums/Timeout.java
+++ b/src/TwitchRecover.Core/Enums/Timeout.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Feeds.java
+++ b/src/TwitchRecover.Core/Feeds.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Feeds.java
+++ b/src/TwitchRecover.Core/Feeds.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/FileIO.java
+++ b/src/TwitchRecover.Core/FileIO.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/FileIO.java
+++ b/src/TwitchRecover.Core/FileIO.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Fuzz.java
+++ b/src/TwitchRecover.Core/Fuzz.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Fuzz.java
+++ b/src/TwitchRecover.Core/Fuzz.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */
@@ -39,7 +39,6 @@ public class Fuzz {
      * @param streamID Long value which represents the stream ID for which clips should be fuzzed for.
      * @param duration Long value which represents the duration of the stream.
      * @param wfuzz    Boolean which represents whether Wfuzz is installed and should be used or not.
-     * @param cli      Boolean which represents whether the method calling this is the CLI or GUI version.
      * @return ArrayList<String>    String arraylist which holds all of the results of clips.
      */
     public static ArrayList<String> fuzz(long streamID, long duration, boolean wfuzz) {
@@ -58,7 +57,6 @@ public class Fuzz {
      * Method which utlises Wfuzz for fuzzing clips from a stream.
      * @param streamID Long value which represents the stream ID for which clips should be fuzzed for.
      * @param reps     Integer value which represents the maximum range for a particular stream.
-     * @param cli      Boolean which represents whether the method calling this is the CLI or GUI version.
      * @return ArrayList<String>    String arraylist which holds all of the results of clips.
      */
     private static ArrayList<String> wfuzz(long streamID, int reps) {

--- a/src/TwitchRecover.Core/Highlights.java
+++ b/src/TwitchRecover.Core/Highlights.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */
@@ -21,7 +21,6 @@ import TwitchRecover.Core.API.VideoAPI;
 import TwitchRecover.Core.Downloader.Download;
 import TwitchRecover.Core.Enums.ContentType;
 import TwitchRecover.Core.Enums.FileExtension;
-import TwitchRecover.Core.Enums.Quality;
 
 import java.util.ArrayList;
 import java.util.regex.Matcher;
@@ -95,7 +94,6 @@ public class Highlights {
      * This method retrieves
      * all existing qualities
      * of a highlight.
-     * @param url       String value representing the source M3U8 URL of the highlight.
      * @return Feeds    Feeds object containing all of the feeds and their corresponding qualities that could be found.
      */
     public Feeds retrieveQualities(){

--- a/src/TwitchRecover.Core/Highlights.java
+++ b/src/TwitchRecover.Core/Highlights.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Live.java
+++ b/src/TwitchRecover.Core/Live.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Live.java
+++ b/src/TwitchRecover.Core/Live.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassCore.java
+++ b/src/TwitchRecover.Core/Mass/MassCore.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassCore.java
+++ b/src/TwitchRecover.Core/Mass/MassCore.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassDownload.java
+++ b/src/TwitchRecover.Core/Mass/MassDownload.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassDownload.java
+++ b/src/TwitchRecover.Core/Mass/MassDownload.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassRecover.java
+++ b/src/TwitchRecover.Core/Mass/MassRecover.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/Mass/MassRecover.java
+++ b/src/TwitchRecover.Core/Mass/MassRecover.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/VOD.java
+++ b/src/TwitchRecover.Core/VOD.java
@@ -122,8 +122,13 @@ public class VOD {
      * @return Feeds    Feeds object containing all possible feeds of a deleted VOD.
      */
     public Feeds retrieveVODFeeds(){
-        feeds=VODRetrieval.retrieveVODFeeds(retrievedURLs.get(0));
-        return feeds;
+        if(retrievedURLs.isEmpty()){
+            return null;
+        }
+        else{
+            feeds=VODRetrieval.retrieveVODFeeds(retrievedURLs.get(0));
+            return feeds;
+        }
     }
 
     /**

--- a/src/TwitchRecover.Core/VOD.java
+++ b/src/TwitchRecover.Core/VOD.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/VOD.java
+++ b/src/TwitchRecover.Core/VOD.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/VODRetrieval.java
+++ b/src/TwitchRecover.Core/VODRetrieval.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/VODRetrieval.java
+++ b/src/TwitchRecover.Core/VODRetrieval.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/WebsiteRetrieval.java
+++ b/src/TwitchRecover.Core/WebsiteRetrieval.java
@@ -188,14 +188,14 @@ public class WebsiteRetrieval {
         }
 
         //Retrieve user ID:
-        String idJSON = getJSON("https://api.twitch.tv/v5/users/?login=" + results[2] + "&client_id=ohroxg880bxrq1izlrinohrz3k4vy6");
+        String idJSON = getJSON("https://api.twitch.tv/v5/users/?login=" + results[0] + "&client_id=ohroxg880bxrq1izlrinohrz3k4vy6");
         JSONObject joID = new JSONObject(idJSON);
-        JSONObject users = joID.getJSONObject("users");
-        JSONObject user = users.getJSONObject("0");
+        JSONArray users = joID.getJSONArray("users");
+        JSONObject user = users.getJSONObject(0);
         userID = user.getString("_id");
 
         //Retrieve stream values:
-        String dataJSON = getJSON("https://alla.streamscharts.com/api/free/streaming/platforms/1/channels/" + userID + "/streams/" + results[2] + "/statuses");
+        String dataJSON = getJSON("https://alla.streamscharts.com/api/free/streaming/platforms/1/channels/" + userID + "/streams/" + results[1] + "/statuses");
         JSONObject joD = new JSONObject(dataJSON);
         JSONArray items = joD.getJSONArray("items");
         for(int i = 0; i < items.length(); i++) {

--- a/src/TwitchRecover.Core/WebsiteRetrieval.java
+++ b/src/TwitchRecover.Core/WebsiteRetrieval.java
@@ -17,17 +17,16 @@
 
 package TwitchRecover.Core;
 
-import jdk.nashorn.internal.parser.JSONParser;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.ProtocolException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.net.URL;
-import java.net.HttpURLConnection;
 
 /**
  * This class contains the core method for website data
@@ -153,9 +152,9 @@ public class WebsiteRetrieval {
                 results[3] = dm.group(1);
             }
             //Get the streamer's name and the VOD ID:
-            String pattern = "twitchtracker\\.com\\/([a-zA-Z0-9]*)\\/streams\\/(\\d*)\\/";
+            String pattern = "twitchtracker\\.com\\/([a-zA-Z0-9-_]*)\\/streams\\/(\\d*)";
             Pattern r = Pattern.compile(pattern);
-            Matcher m = r.matcher(url + "/");
+            Matcher m = r.matcher(url);
             if(m.find()) {
                 results[0] = m.group(1);
                 results[1] = m.group(2);
@@ -180,9 +179,9 @@ public class WebsiteRetrieval {
         String userID;
         double duration = 0.0;
         //Retrieve initial values:
-        String pattern = "streamscharts\\.com\\/twitch\\/channels\\/([a-zA-Z0-9]*)\\/streams\\/(\\d*)\\/";
+        String pattern = "streamscharts\\.com\\/twitch\\/channels\\/([a-zA-Z0-9_-]*)\\/streams\\/(\\d*)";
         Pattern r = Pattern.compile(pattern);
-        Matcher m = r.matcher(url + "/");
+        Matcher m = r.matcher(url);
         if(m.find()) {
             results[0] = m.group(1);
             results[1] = m.group(2);

--- a/src/TwitchRecover.Core/WebsiteRetrieval.java
+++ b/src/TwitchRecover.Core/WebsiteRetrieval.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0aH 2.0a    Hotifx
+ *  @version 2.0aH     2.0a Hotfix
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */

--- a/src/TwitchRecover.Core/WebsiteRetrieval.java
+++ b/src/TwitchRecover.Core/WebsiteRetrieval.java
@@ -10,7 +10,7 @@
  * If not see http://www.gnu.org/licenses/ or write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  @author Daylam Tayari daylam@tayari.gg https://github.com/daylamtayari
- *  @version 2.0a
+ *  @version 2.0aH 2.0a    Hotifx
  *  Github project home page: https://github.com/TwitchRecover
  *  Twitch Recover repository: https://github.com/TwitchRecover/TwitchRecover
  */


### PR DESCRIPTION
Merging all of the program files for the 2.0aH release, the hotfix for the 2.0 alpha version of Twitch Recover which fixes the Twitch API change and some other relatively minor bugs that had appeared prior to then, into the master branch.