### PR TITLE
add cli argument for alternate temp path

### DIFF
--- a/src/TwitchRecover.CLI/CLI.java
+++ b/src/TwitchRecover.CLI/CLI.java
@@ -17,16 +17,38 @@
 
 package TwitchRecover.CLI;
 
+import java.util.Objects;
+
 /**
  * CLI class which is the root of the CLI
  * version of Twitch Recover.
  */
 public class CLI {
+
+    public static String OVERRIDE_TEMP_PATH;    // Can be used to override the temporary download path
+
     /**
      * Core method of the CLI version of Twitch Recover.
      * @param args
      */
     public static void main(String[] args){
+        extractArguments(args);
         CLIHandler.main();
+    }
+
+    /**
+     * Goes through all cli arguments and sets
+     * properties accordingly.
+     * @param args  Command line arguments passed in when executing
+     */
+    private static void extractArguments(String[] args) {
+        for (int i = 0; i < args.length; i++) {
+            if (Objects.equals(args[i], "--temppath") || Objects.equals(args[i], "-tp")) {
+                if (args.length > i + 1) {
+                    OVERRIDE_TEMP_PATH = args[i + 1];
+                    break; // Exit after argument found
+                }
+            }
+        }
     }
 }

--- a/src/TwitchRecover.Core/Downloader/FileHandler.java
+++ b/src/TwitchRecover.Core/Downloader/FileHandler.java
@@ -17,13 +17,15 @@
 
 package TwitchRecover.Core.Downloader;
 
-import TwitchRecover.Core.Enums.FileExtension;
+import TwitchRecover.CLI.CLI;
 import lombok.Cleanup;
 import org.apache.commons.io.IOUtils;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.NavigableMap;
+import java.util.UUID;
 
 /**
  * This class handles all of the file handling
@@ -38,8 +40,14 @@ class FileHandler {
      * @throws IOException
      */
     protected static void createTempFolder() throws IOException {
-        TEMP_FOLDER_PATH= Files.createTempDirectory("TwitchRecover-").toAbsolutePath();
+        if (CLI.OVERRIDE_TEMP_PATH == null) {
+            TEMP_FOLDER_PATH= Files.createTempDirectory("TwitchRecover-").toAbsolutePath();
+        } else {
+            TEMP_FOLDER_PATH = Paths.get(CLI.OVERRIDE_TEMP_PATH).resolve("TwitchRecover-" + UUID.randomUUID());
+        }
+
         File tempDir=new File(String.valueOf(TEMP_FOLDER_PATH));
+        tempDir.mkdirs();
         tempDir.deleteOnExit();
     }
 


### PR DESCRIPTION
Quick workaround to enable custom temp (download) paths via startup argument.
I needed this but maybe it's worth keeping for others until you find a permanent solution you like.